### PR TITLE
Speed improvement for large projects & path fixup for sln/vxproj inputs

### DIFF
--- a/extractheaders/extractheaders.cpp
+++ b/extractheaders/extractheaders.cpp
@@ -90,7 +90,7 @@ public:
 	queue<path> userheadersqueue;
 	set<path> headersprocessed;
 	set<path> includedirs;
-	vector<string> sysincludedirs;
+	set<string> sysincludedirs;
 	// system or thirdparty headers
 	set<boost::filesystem::path> systemheaders;
 
@@ -265,14 +265,14 @@ void ExtractHeadersImpl::add_system_includes(context_type& ctx)
 
 	for (auto& sysdir : input.sysincludetreedirs) {
 
-		sysincludedirs.push_back(sysdir);
+		sysincludedirs.insert(sysdir);
 
 		if (is_directory(sysdir)) {
 			vector<string> dirs = getAllDirsInDir(sysdir.c_str());
 
 			for (auto& dir : dirs) {
 
-				sysincludedirs.push_back(dir);
+				sysincludedirs.insert(dir);
 			}
 		}
 	}
@@ -368,7 +368,7 @@ void ExtractHeadersImpl::process_file(const path& filename)
 
 	for (const auto& includeDir : input.sysincludedirs)
 	{
-		sysincludedirs.push_back(includeDir);
+		sysincludedirs.insert(includeDir);
 	}
 
 	input.excludeheaders.push_back("stdafx.h");

--- a/extractheaders/extractheaders.cpp
+++ b/extractheaders/extractheaders.cpp
@@ -580,7 +580,7 @@ void ExtractHeadersImpl::run()
 			else if (!exists(input_path))
 				output.errorStream << "Cannot find: " << input_path << "\n";
 			else
-				userheadersqueue.push(boost::filesystem::canonical(input));
+				userheadersqueue.push(boost::filesystem::canonical(input_path));
 		}
 	}
 

--- a/extractheaders/vsparsing.cpp
+++ b/extractheaders/vsparsing.cpp
@@ -32,8 +32,9 @@ void VcxprojParsing::parse(vector<ProjectConfiguration>& configurations,
 
 			while (projectConfiguration) {
 				const char* label = projectConfiguration->Attribute("Include");
+				const char* configurationName = projectConfiguration->FirstChildElement("Configuration")->GetText();
 
-				configurations.push_back({label});
+				configurations.push_back({label, configurationName});
 				projectConfiguration = projectConfiguration->NextSiblingElement("ProjectConfiguration");
 			}
 		}

--- a/extractheaders/vsparsing.h
+++ b/extractheaders/vsparsing.h
@@ -7,6 +7,7 @@
 
 struct ProjectConfiguration {
 	std::string name;
+	std::string configuration;
 	std::string definitions;
 	std::string additionalIncludeDirectories;
 	std::string precompiledHeaderFile;


### PR DESCRIPTION
Was playing with this last week (before your email even! How coincidental!) and noticed these few small tweaks were required to get my current project going with your new and very cool vxproj integration.

A minor suggestion if you're interested, there's a lot of trailing whitespace in these files. If you're using Visual Studio, it might be worth installing https://visualstudiogallery.msdn.microsoft.com/a204e29b-1778-4dae-affd-209bea658a59 which can automatically clean this up for you on save.